### PR TITLE
New customization options: font and top bar text color

### DIFF
--- a/ImgButton.qml
+++ b/ImgButton.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import QtGraphicalEffects 1.0
 
 Rectangle {
     id: button
@@ -9,6 +10,9 @@ Rectangle {
     property url normalImg: ""
     property url hoverImg: normalImg
     property url pressImg: normalImg
+    property color normalColor: "transparent"
+    property color hoverColor: normalColor
+    property color pressColor: normalColor
 
     signal clicked()
     signal enterPressed()
@@ -21,18 +25,38 @@ Rectangle {
         height: parent.height
         anchors.centerIn: parent
     }
+    
+    ColorOverlay {
+        id: imgOverlay
+        anchors.fill: img
+        source: img
+        color: normalColor
+    }
 
     MouseArea {
         anchors.fill: parent
         hoverEnabled: true
-        onEntered: img.source = hoverImg
-        onPressed: img.source = pressImg
-        onExited: img.source = normalImg
-        onReleased: img.source = normalImg
+        onEntered: {
+            img.source = hoverImg
+            imgOverlay.color = hoverColor
+        }
+        onPressed: {
+            img.source = pressImg
+            imgOverlay.color = pressColor
+        }
+        onExited: {
+            img.source = normalImg
+            imgOverlay.color = normalColor
+        }
+        onReleased: {
+            img.source = normalImg
+            imgOverlay.color = normalColor
+        }
         onClicked: button.clicked()
     }
     Component.onCompleted: {
         img.source = normalImg
+        imgOverlay.color = normalColor
     }
     Keys.onPressed: {
         if (event.key == Qt.Key_Return || event.key == Qt.Key_Enter) {

--- a/LoginFrame.qml
+++ b/LoginFrame.qml
@@ -211,6 +211,7 @@ Item {
             }
             text: userName
             color: "#000000"
+            font.family: config.font
             font.pointSize: 15
         }
 
@@ -261,6 +262,8 @@ Item {
                 color: config.accent2
                 implicitHeight: 40
             }
+
+            font.family: config.font
 
             anchors {
                 top: passwdInput.bottom

--- a/Main.qml
+++ b/Main.qml
@@ -190,6 +190,7 @@ Rectangle {
                     leftMargin: hMargin
                 }
 
+                font.family: config.font
                 font.pointSize: 16
 
                 color: config.accent1_text
@@ -212,6 +213,7 @@ Rectangle {
                         centerIn: parent
                     }
 
+                    font.family: config.font
                     font.pointSize: 16
 
                     color: config.accent1_text
@@ -374,6 +376,8 @@ Rectangle {
                 color: config.accent2
                 implicitHeight: 40
             }
+
+            font.family: config.font
 
             anchors {
                 bottom: parent.bottom

--- a/Main.qml
+++ b/Main.qml
@@ -192,6 +192,8 @@ Rectangle {
 
                 font.pointSize: 16
 
+                color: config.accent1_text
+
                 text: sddm.hostName ? sddm.hostName : "hostname"
             }
 
@@ -211,6 +213,8 @@ Rectangle {
                     }
 
                     font.pointSize: 16
+
+                    color: config.accent1_text
 
                     function updateTime() {
                         text = new Date().toLocaleString(Qt.locale("en_US"), "hh:mm:ss")
@@ -267,6 +271,7 @@ Rectangle {
                         visible: sessionFrame.isMultipleSessions()
                         normalImg: "icons/switchframe/session.png"
                         pressImg: "icons/switchframe/session_focus.png"
+                        normalColor: config.accent1_text
                         onClicked: {
                             root.state = "stateSession"
                             sessionFrame.focus = true
@@ -292,6 +297,7 @@ Rectangle {
 
                         normalImg: "icons/switchframe/user.png"
                         pressImg: "icons/switchframe/user_focus.png"
+                        normalColor: config.accent1_text
                         onClicked: {
                             root.state = "stateUser"
                             userFrame.focus = true
@@ -316,6 +322,7 @@ Rectangle {
 
                         normalImg: "icons/switchframe/powermenu.png"
                         pressImg: "icons/switchframe/powermenu_focus.png"
+                        normalColor: config.accent1_text
                         onClicked: {
                             root.state = "statePower"
                             powerFrame.focus = true

--- a/MaterialTextbox.qml
+++ b/MaterialTextbox.qml
@@ -6,6 +6,7 @@ import QtQuick.Controls 2.0
 TextField {
     clip: true
     color: config.accent2
+    font.family: config.font
     font.pointSize: 15
     selectByMouse: true
     selectionColor: "#a8d6ec"

--- a/PowerFrame.qml
+++ b/PowerFrame.qml
@@ -36,6 +36,7 @@ Item {
 
             Text {
                 text: qsTr("Shutdown")
+                font.family: config.font
                 font.pointSize: 15
                 color: "white"
                 horizontalAlignment: Text.AlignHCenter
@@ -66,6 +67,7 @@ Item {
 
             Text {
                 text: qsTr("Reboot")
+                font.family: config.font
                 font.pointSize: 15
                 color: "white"
                 horizontalAlignment: Text.AlignHCenter
@@ -96,6 +98,7 @@ Item {
 
             Text {
                 text: qsTr("Suspend")
+                font.family: config.font
                 font.pointSize: 15
                 color: "white"
                 horizontalAlignment: Text.AlignHCenter

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ the defaults.
   `/usr/share/xsessions/sessionname.desktop` (i.e. `cinnamon` or `cinnamon2d`,
   NOT `Cinnamon (Software Rendering)`)
 * `accent1`: The color of the top bar
+* `accent1_text`: The color of the top bar text and buttons
 * `accent2`: The color of other items, like the "LOG IN" button
 * `accent2_hover`: The color that will be applied on hover to accent2 items
 * `logo` (optional): Path to the image that will be placed in the spot usually

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ the defaults.
 * `default_session`: Session name to default to.  This is the `sessionname` in
   `/usr/share/xsessions/sessionname.desktop` (i.e. `cinnamon` or `cinnamon2d`,
   NOT `Cinnamon (Software Rendering)`)
+* `font`: The name of font family to use in labels and fields
 * `accent1`: The color of the top bar
 * `accent1_text`: The color of the top bar text and buttons
 * `accent2`: The color of other items, like the "LOG IN" button

--- a/SessionFrame.qml
+++ b/SessionFrame.qml
@@ -67,6 +67,7 @@ Item {
         font {
             pointSize: 18
             bold: true
+            family: config.font
         }
         wrapMode: Text.Wrap
     }
@@ -100,6 +101,7 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 text: name
+                font.family: config.font
                 font.pointSize: 15
                 color: "black"
                 wrapMode: Text.WordWrap

--- a/UsageFrame.qml
+++ b/UsageFrame.qml
@@ -54,6 +54,7 @@ Item {
             font {
                 pointSize: 18
                 bold: true
+                family: config.font
             }
             wrapMode: Text.Wrap
         }
@@ -67,6 +68,7 @@ Item {
             }
             text: config.aup
             color: "#000000"
+            font.family: config.font
             font.pointSize: 15
             wrapMode: Text.Wrap
         }

--- a/UserFrame.qml
+++ b/UserFrame.qml
@@ -88,6 +88,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter
                 text: name
+                font.family: config.font
                 font.pointSize: 15
                 color: "white"
                 wrapMode: Text.WordWrap

--- a/theme.conf
+++ b/theme.conf
@@ -1,6 +1,7 @@
 [General]
 default_background=background.png
 default_session=cinnamon
+font=sans
 accent1=#4dd0e1
 accent1_text=#000000
 accent2=#00796b

--- a/theme.conf
+++ b/theme.conf
@@ -2,6 +2,7 @@
 default_background=background.png
 default_session=cinnamon
 accent1=#4dd0e1
+accent1_text=#000000
 accent2=#00796b
 accent2_hover=#009688
 user_name=select


### PR DESCRIPTION
Greetings.

I've implemented two new customization options:
- `accent1_text`: changes color of top bar text (also recolors icons to match) (by default equals to `#000000`)
- `font`: changes font of all labels and fields (by default equals to `sans`)

To implement `accent1_text` to recoloring icons, I implemented these properties to `ImgButton`:
- `normalColor`: idle image color (by default equals to `transparent`)
- `hoverColor`: hover image color (by default equals to value of `normalColor`)
- `pressColor`: pressed image color (by default equals to value of `normalColor`)

Default configuration file `theme.conf` and `README.md` was also updated to reflect changes.