### PR TITLE
Fix user avatar drawing on top of previous one

### DIFF
--- a/UserAvatar.qml
+++ b/UserAvatar.qml
@@ -10,6 +10,7 @@ Canvas {
     onSourceChanged: delayPaintTimer.running = true
     onPaint: {
         var ctx = getContext("2d");
+        ctx.clearRect(0, 0, width, height);
         ctx.beginPath()
         ctx.ellipse(0, 0, width, height)
         ctx.clip()


### PR DESCRIPTION
Greetings.

Introduced commit fixes the following bug: when switching between users or switching user avatar state, new avatar redraws on top of existing avatar. Problem is much clearer when using avatars with transparency.

The solution is to clear drawing context before every drawing.