### PR TITLE
Additional fallback to previous session

### DIFF
--- a/LoginFrame.qml
+++ b/LoginFrame.qml
@@ -19,7 +19,13 @@ Item {
                 return i
             }
         }
-        return 0
+        
+        if (sessionModel.lastIndex >= 0 && sessionModel.lastIndex < sessionModel.rowCount() ) {
+            return sessionModel.lastIndex
+        }
+        else {
+            return 0
+        }
     }
 
     Connections {


### PR DESCRIPTION
Greetings.

There is a bug: when booting PC and trying to log in without choosing session, it selects first installed session instead of previous one. Similiar bug was described in #3.

Fix: before returning `0` (first installed session), try to return `sessionModel.lastIndex`, as it contains index of previous session.